### PR TITLE
Do not shell out to sniff ruby and rubygems version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Bumped the Timecop verison for development to 0.9
 * RuboCop fixes
 
+### Fixed
+
+* [#9](https://github.com/civisanalytics/ruby_audit/pull/9) Do not shell out to sniff ruby and rubygems version
+
 ## [1.2.0] - 2017-09-21
 
 ### Added

--- a/lib/ruby_audit/scanner.rb
+++ b/lib/ruby_audit/scanner.rb
@@ -42,13 +42,12 @@ module RubyAudit
     def ruby_version
       # .gsub to separate strings (e.g., 2.1.0dev -> 2.1.0.dev,
       # 2.2.0preview1 -> 2.2.0.preview.1).
-      `ruby --version`.split[1]
-                      .gsub(/(\d)([a-z]+)/, '\1.\2')
-                      .gsub(/([a-z]+)(\d)/, '\1.\2')
+      RUBY_VERSION.gsub(/(\d)([a-z]+)/, '\1.\2')
+                  .gsub(/([a-z]+)(\d)/, '\1.\2')
     end
 
     def rubygems_version
-      `gem --version`.strip
+      Gem::VERSION
     end
 
     def scan_inner(specs, type, options = {})


### PR DESCRIPTION
When running on jruby using `java -jar jruby-complete.jar`, this causes
incorrect ruby and rubygem version detection because it picks up the
`ruby` and `rubygems` executable on `PATH` and not the ruby version that
the program is currently running with.