### PR TITLE
Allow ignoring advisories by their GHSA identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ $ ruby-audit check -n
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies.
-Then, run `rake spec` to run the tests.
+You'll also want to run `git submodule update --init` to populate the ruby-advisory-db
+submodule used for testing. Then, run `rake spec` to run the tests.
 You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`.

--- a/lib/ruby_audit/scanner.rb
+++ b/lib/ruby_audit/scanner.rb
@@ -59,8 +59,7 @@ module RubyAudit
 
       specs.each do |spec|
         @database.send("check_#{type}".to_sym, spec) do |advisory|
-          unless ignore.include?(advisory.cve_id) ||
-                 ignore.include?(advisory.osvdb_id)
+          unless ignore.intersect?(advisory.identifiers.to_set)
             yield UnpatchedGem.new(spec, advisory)
           end
         end

--- a/ruby_audit.gemspec
+++ b/ruby_audit.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bundler-audit', '>= 0.6.0', '< 0.8.0'
+  spec.add_dependency 'bundler-audit', '~> 0.7.0'
   spec.add_development_dependency 'bundler', '>= 1.17', '< 2.1'
   spec.add_development_dependency 'pry', '~> 0.12.2'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
rubysec/bundler-audit#217 adds compatibility with GHSA identifiers, and was released in bundler-audit v0.7.0.  This PR allows users to `--ignore` by GHSA identifiers, as well as any types of identifiers that might get added by bundler-audit in the future.

---

#13 first added compatibility with bundler-audit v0.7.x, but after I thought about it some more, I guess we should be fine to just require bundler-audit v0.7.x?  I'm thinking that users who upgrade to the latest version of ruby-audit would also want to upgrade to the latest bundler-audit anyway.  What do you think?

Also, I was going to add specs to ensure that GHSA identifiers could be ignored by, but it looks like our spec strategy is to reference real advisories in the database (as opposed to adding mock ones during testing), and there aren't any ruby or rubygems advisories in ruby-advisory-db with GHSA identifiers yet.  I tested locally by adding a fake one to my local ruby-advisory-db submodule, so I'm pretty sure it works.  What do you think I should do?