### PR TITLE
Compatibility with bundler-audit 0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [2.0.0] - 2021-03-22
+
 ### Added
 
 * Require bundler-audit 0.8
-* Added Ruby 3.0 to the Travis matrix, no changes needed
+* Added Ruby 3.0 to the Travis matrix
 
 ### Removed
 
@@ -75,7 +77,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Initial Release
 
-[Unreleased]: https://github.com/civisanalytics/ruby_audit/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/civisanalytics/ruby_audit/compare/v2.0.0...HEAD
+[1.3.0]: https://github.com/civisanalytics/ruby_audit/compare/v1.3.0...v2.0.0
 [1.3.0]: https://github.com/civisanalytics/ruby_audit/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/civisanalytics/ruby_audit/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/civisanalytics/ruby_audit/compare/v1.0.1...v1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+* Require bundler-audit 0.8
 * Added Ruby 3.0 to the Travis matrix, no changes needed
+
+### Removed
+
+* Removed support for bundler-audit 0.7
 
 ## [1.3.0] - 2020-07-01
 

--- a/lib/ruby_audit.rb
+++ b/lib/ruby_audit.rb
@@ -1,4 +1,3 @@
-require 'bundler/audit/cli'
 require 'ruby_audit/cli'
 require 'ruby_audit/database'
 require 'ruby_audit/scanner'

--- a/lib/ruby_audit/cli.rb
+++ b/lib/ruby_audit/cli.rb
@@ -52,6 +52,72 @@ module RubyAudit
 
     private
 
+    def say(message = '', color = nil)
+      color = nil unless $stdout.tty?
+      super(message.to_s, color)
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/PerceivedComplexity
+    def print_advisory(gem, advisory)
+      say 'Name: ', :red
+      say gem.name
+
+      say 'Version: ', :red
+      say gem.version
+
+      say 'Advisory: ', :red
+
+      if advisory.cve
+        say advisory.cve_id
+      elsif advisory.osvdb
+        say advisory.osvdb_id
+      elsif advisory.ghsa
+        say advisory.ghsa_id
+      end
+
+      say 'Criticality: ', :red
+      case advisory.criticality
+      when :none     then say 'None'
+      when :low      then say 'Low'
+      when :medium   then say 'Medium', :yellow
+      when :high     then say 'High', %i[red bold]
+      when :critical then say 'Critical', %i[red bold]
+      else                say 'Unknown'
+      end
+
+      say 'URL: ', :red
+      say advisory.url
+
+      if options.verbose?
+        say 'Description:', :red
+        say
+
+        print_wrapped advisory.description, indent: 2
+        say
+      else
+
+        say 'Title: ', :red
+        say advisory.title
+      end
+
+      if advisory.patched_versions.empty?
+        say 'Solution: ', :red
+        say 'remove or disable this gem until a patch is available!', %i[red bold]
+      else
+        say 'Solution: upgrade to ', :red
+        say advisory.patched_versions.join(', ')
+      end
+
+      say
+    end
+    # rubocop:enable Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/MethodLength
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/AbcSize
+
     def check_for_stale_database
       database = Database.new
       return unless database.size == 89

--- a/lib/ruby_audit/cli.rb
+++ b/lib/ruby_audit/cli.rb
@@ -1,5 +1,10 @@
+require 'thor'
+
 module RubyAudit
-  class CLI < Bundler::Audit::CLI
+  class CLI < ::Thor
+    default_task :check
+    map '--version' => :version
+
     desc 'check', 'Checks Ruby and RubyGems for insecure versions'
     method_option :ignore, type: :array, aliases: '-i'
     method_option :no_update, type: :boolean, aliases: '-n'

--- a/lib/ruby_audit/database.rb
+++ b/lib/ruby_audit/database.rb
@@ -1,3 +1,5 @@
+require 'bundler/audit/database'
+
 module RubyAudit
   class Database < Bundler::Audit::Database
     def advisories_for(name, type)

--- a/lib/ruby_audit/scanner.rb
+++ b/lib/ruby_audit/scanner.rb
@@ -61,7 +61,9 @@ module RubyAudit
 
       specs.each do |spec|
         @database.send("check_#{type}".to_sym, spec) do |advisory|
-          yield UnpatchedGem.new(spec, advisory) unless ignore.intersect?(advisory.identifiers.to_set)
+          unless ignore.intersect?(advisory.identifiers.to_set)
+            yield Bundler::Audit::Results::UnpatchedGem.new(spec, advisory)
+          end
         end
       end
     end

--- a/lib/ruby_audit/scanner.rb
+++ b/lib/ruby_audit/scanner.rb
@@ -1,5 +1,8 @@
+require 'bundler/audit/results/unpatched_gem'
+require 'set'
+
 module RubyAudit
-  class Scanner < Bundler::Audit::Scanner
+  class Scanner
     class Version
       def initialize(name, version)
         @name = name
@@ -9,11 +12,9 @@ module RubyAudit
       attr_reader :name, :version
     end
 
-    # rubocop:disable Lint/MissingSuper
     def initialize
       @database = Database.new
     end
-    # rubocop:enable Lint/MissingSuper
 
     def scan(options = {}, &block)
       return enum_for(__method__, options) unless block

--- a/lib/ruby_audit/version.rb
+++ b/lib/ruby_audit/version.rb
@@ -1,3 +1,3 @@
 module RubyAudit
-  VERSION = '1.3.0'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/ruby_audit.gemspec
+++ b/ruby_audit.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bundler-audit', '~> 0.8.0.rc1'
+  spec.add_dependency 'bundler-audit', '~> 0.8.0.rc2'
   spec.add_development_dependency 'pry', '~> 0.13.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'

--- a/ruby_audit.gemspec
+++ b/ruby_audit.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bundler-audit', '~> 0.7.0'
+  spec.add_dependency 'bundler-audit', '~> 0.8.0.rc1'
   spec.add_development_dependency 'pry', '~> 0.13.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'

--- a/ruby_audit.gemspec
+++ b/ruby_audit.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bundler-audit', '~> 0.8.0.rc2'
+  spec.add_dependency 'bundler-audit', '~> 0.8.0'
   spec.add_development_dependency 'pry', '~> 0.13.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'timecop'
 
 RSpec.configure do |config|
   config.before(:each) do
-    stub_const('Bundler::Audit::Database::VENDORED_PATH',
+    stub_const('Bundler::Audit::Database::DEFAULT_PATH',
                File.join(File.dirname(__FILE__), '..', 'vendor',
                          'ruby-advisory-db'))
   end


### PR DESCRIPTION
[bundler-audit](https://github.com/rubysec/bundler-audit) is nearing the release of v0.8.0, and because ruby_audit hooks in to so many of its internals, the two are not compatible.  Users would not be able to run the current version of ruby_audit alongside bundler-audit v0.8.0.

The aim of this PR is to be compatible with bundler-audit v0.8.0, and necessarily drop compatibility with bundler-audit v0.7.  Of course, this can't go in until bundler-audit v0.8.0 is released, but I'd like for us to be ready to go.

A secondary aim of this PR is to reduce the coupling between the gems.  It was good to build atop bundler-audit's work in the beginning, but I think the best direction going forward is to allow the gems to diverge.  (The most useful part of their code for us is the `Database` class, for how it interacts with the `ruby-advisory-db` and manages updating the repo.)