### PR TITLE
increase the bundler-audit version to 0.9.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+* Require bundler-audit 0.9.0.1
+
 ## [2.0.0] - 2021-03-22
 
 ### Added

--- a/ruby_audit.gemspec
+++ b/ruby_audit.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bundler-audit', '~> 0.8.0'
+  spec.add_dependency 'bundler-audit', '~> 0.9.0', '>= 0.9.0.1'
   spec.add_development_dependency 'pry', '~> 0.13.0'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'


### PR DESCRIPTION
FYI: bundler-audit v0.9.0.1 contains a workaround for Psych < 3.1.0 to
support running on Ruby < 2.6.  (Although, ruby 2.5 has reached EOL!)