### PR TITLE
Use correct version for jruby

### DIFF
--- a/lib/ruby_audit/scanner.rb
+++ b/lib/ruby_audit/scanner.rb
@@ -26,7 +26,9 @@ module RubyAudit
     end
 
     def scan_ruby(options = {}, &block)
-      version = if RUBY_PATCHLEVEL < 0
+      version = if RUBY_ENGINE == "jruby"
+                  "#{JRUBY_VERSION}"
+                elsif RUBY_PATCHLEVEL < 0
                   ruby_version
                 else
                   "#{RUBY_VERSION}.#{RUBY_PATCHLEVEL}"

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -5,59 +5,76 @@ describe RubyAudit::Scanner do
 
   subject { scanner.scan.to_a }
 
-  before(:each) do
-    stub_const('RUBY_VERSION', '2.2.1')
-    stub_const('RUBY_ENGINE', 'ruby')
-    stub_const('RUBY_PATCHLEVEL', 85)
-    allow_any_instance_of(RubyAudit::Scanner)
-      .to receive(:rubygems_version).and_return('2.4.5')
+  context 'jruby' do
+    before(:each) do
+      stub_const('RUBY_ENGINE', 'jruby')
+      stub_const('JRUBY_VERSION', '1.4.0')
+      allow_any_instance_of(RubyAudit::Scanner)
+        .to receive(:rubygems_version).and_return('2.4.5')
+    end
+
+    it 'handles jruby versions' do
+      allow_any_instance_of(RubyAudit::Scanner)
+        .to receive(:ruby_version).and_return('1.4.0')
+      expect(subject.map { |r| r.advisory.id }).to include('CVE-2010-1330')
+    end
   end
 
-  context 'when auditing an unpatched Ruby' do
-    it 'should match an unpatched Ruby to its advisories' do
-      expect(subject.all? do |result|
-               result.advisory.vulnerable?(result.gem.version)
-             end).to be_truthy
-      expect(subject.map { |r| r.advisory.id }).to include('OSVDB-120541')
-    end
-
-    it 'respects patch level' do
-      stub_const('RUBY_VERSION', '1.9.3')
-      stub_const('RUBY_PATCHLEVEL', 392)
-      expect(subject.map { |r| r.advisory.id }).to include('OSVDB-113747')
-    end
-
-    it 'handles preview versions' do
-      stub_const('RUBY_VERSION', '2.1.0')
-      stub_const('RUBY_PATCHLEVEL', -1)
+  context 'ruby' do
+    before(:each) do
+      stub_const('RUBY_VERSION', '2.2.1')
+      stub_const('RUBY_ENGINE', 'ruby')
+      stub_const('RUBY_PATCHLEVEL', 85)
       allow_any_instance_of(RubyAudit::Scanner)
-        .to receive(:ruby_version).and_return('2.1.0.dev')
-      expect(subject.map { |r| r.advisory.id }).to include('OSVDB-100113')
+        .to receive(:rubygems_version).and_return('2.4.5')
     end
 
-    context 'when the :ignore option is given' do
-      subject { scanner.scan(ignore: ['OSVDB-120541']) }
+    context 'when auditing an unpatched Ruby' do
+      it 'should match an unpatched Ruby to its advisories' do
+        expect(subject.all? do |result|
+          result.advisory.vulnerable?(result.gem.version)
+        end).to be_truthy
+        expect(subject.map { |r| r.advisory.id }).to include('OSVDB-120541')
+      end
 
-      it 'should ignore the specified advisories' do
-        expect(subject.map { |r| r.advisory.id }).not_to include('OSVDB-120541')
+      it 'respects patch level' do
+        stub_const('RUBY_VERSION', '1.9.3')
+        stub_const('RUBY_PATCHLEVEL', 392)
+        expect(subject.map { |r| r.advisory.id }).to include('OSVDB-113747')
+      end
+
+      it 'handles preview versions' do
+        stub_const('RUBY_VERSION', '2.1.0')
+        stub_const('RUBY_PATCHLEVEL', -1)
+        allow_any_instance_of(RubyAudit::Scanner)
+          .to receive(:ruby_version).and_return('2.1.0.dev')
+        expect(subject.map { |r| r.advisory.id }).to include('OSVDB-100113')
+      end
+
+      context 'when the :ignore option is given' do
+        subject { scanner.scan(ignore: ['OSVDB-120541']) }
+
+        it 'should ignore the specified advisories' do
+          expect(subject.map { |r| r.advisory.id }).not_to include('OSVDB-120541')
+        end
       end
     end
-  end
 
-  context 'when auditing an unpatched RubyGems' do
-    it 'should match an unpatched RubyGems to its advisories' do
-      expect(subject.all? do |result|
-               result.advisory.vulnerable?(result.gem.version)
-             end).to be_truthy
-      expect(subject.map { |r| r.advisory.id }).to include('CVE-2015-3900')
-    end
+    context 'when auditing an unpatched RubyGems' do
+      it 'should match an unpatched RubyGems to its advisories' do
+        expect(subject.all? do |result|
+          result.advisory.vulnerable?(result.gem.version)
+        end).to be_truthy
+        expect(subject.map { |r| r.advisory.id }).to include('CVE-2015-3900')
+      end
 
-    context 'when the :ignore option is given' do
-      subject { scanner.scan(ignore: ['CVE-2015-3900']) }
+      context 'when the :ignore option is given' do
+        subject { scanner.scan(ignore: ['CVE-2015-3900']) }
 
-      it 'should ignore the specified advisories' do
-        expect(subject.map { |r| r.advisory.id })
-          .not_to include('CVE-2015-3900')
+        it 'should ignore the specified advisories' do
+          expect(subject.map { |r| r.advisory.id })
+            .not_to include('CVE-2015-3900')
+        end
       end
     end
   end


### PR DESCRIPTION
Hello,

Following this new CVE for jruby https://github.com/rubysec/ruby-advisory-db/blob/master/rubies/jruby/CVE-2022-25857.yml we received the following report:

```
Name: jruby
Version: 2.6.8.0
Advisory: CVE-2022-25857
Criticality: High
URL: https://github.com/jruby/jruby/issues/7342 
Title: CVE-2022-25857 jruby/psych/snakeyaml: Denial of Service (DoS) due
 missing to nested depth limitation for collections
Solution: upgrade to >= 9.3.8.0
```

The reported version isn't correct, it uses the supported ruby version and not the jruby version.

I did a patch to use the jruby version when checking from jruby