### PR TITLE
Fix check for rubygems vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+* [#35](https://github.com/civisanalytics/ruby_audit/pull/35)
+Look for rubygems advisories in the correct directory of the ruby-advisory-db
+
+## [2.3.0] - 2024-01-10
+
 ### Added
 
 * Support for Ruby 3.3
@@ -94,8 +101,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Initial Release
 
-[Unreleased]: https://github.com/civisanalytics/ruby_audit/compare/v2.0.0...HEAD
-[1.3.0]: https://github.com/civisanalytics/ruby_audit/compare/v1.3.0...v2.0.0
+[Unreleased]: https://github.com/civisanalytics/ruby_audit/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/civisanalytics/ruby_audit/compare/v2.2.0...v2.3.0
+[2.2.0]: https://github.com/civisanalytics/ruby_audit/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/civisanalytics/ruby_audit/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/civisanalytics/ruby_audit/compare/v1.3.0...v2.0.0
 [1.3.0]: https://github.com/civisanalytics/ruby_audit/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/civisanalytics/ruby_audit/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/civisanalytics/ruby_audit/compare/v1.0.1...v1.1.0

--- a/lib/ruby_audit/database.rb
+++ b/lib/ruby_audit/database.rb
@@ -14,8 +14,8 @@ module RubyAudit
       check(ruby, 'rubies', &block)
     end
 
-    def check_library(library, &block)
-      check(library, 'libraries', &block)
+    def check_rubygems(rubygems, &block)
+      check(rubygems, 'gems', &block)
     end
 
     def check(object, type = 'gems')
@@ -29,8 +29,7 @@ module RubyAudit
     protected
 
     def each_advisory_path(&block)
-      Dir.glob(File.join(@path, '{gems,libraries,rubies}', '*', '*.yml'),
-               &block)
+      Dir.glob(File.join(@path, '{gems,rubies}', '*', '*.yml'), &block)
     end
 
     def each_advisory_path_for(name, type = 'gems', &block)

--- a/lib/ruby_audit/scanner.rb
+++ b/lib/ruby_audit/scanner.rb
@@ -36,8 +36,8 @@ module RubyAudit
     end
 
     def scan_rubygems(options = {}, &block)
-      specs = [Version.new('rubygems', rubygems_version)]
-      scan_inner(specs, 'library', options, &block)
+      specs = [Version.new('rubygems-update', rubygems_version)]
+      scan_inner(specs, 'rubygems', options, &block)
     end
 
     private

--- a/spec/database_spec.rb
+++ b/spec/database_spec.rb
@@ -1,14 +1,14 @@
 require 'spec_helper'
 
 describe RubyAudit::Database do
-  describe '#check_library' do
-    let(:library) { RubyAudit::Scanner::Version.new('rubygems', '2.4.5') }
+  describe '#check_rubygems' do
+    let(:rubygems) { RubyAudit::Scanner::Version.new('rubygems-update', '2.4.5') }
 
     context 'when given a block' do
-      it 'should yield every advisory affecting the library' do
+      it 'should yield every advisory affecting the rubygems version' do
         advisories = []
 
-        subject.check_library(library) do |advisory|
+        subject.check_rubygems(rubygems) do |advisory|
           advisories << advisory
         end
 
@@ -17,14 +17,14 @@ describe RubyAudit::Database do
                  advisory.is_a?(Bundler::Audit::Advisory)
                end).to be_truthy
         expect(advisories.map(&:id)).to include('CVE-2015-3900')
-        expect(advisories.map(&:path).reject { |p| p =~ /libraries/ })
+        expect(advisories.map(&:path).reject { |p| p =~ /rubygems-update/ })
           .to be_empty
       end
     end
 
     context 'when given no block' do
       it 'should return an Enumerator' do
-        expect(subject.check_library(library)).to be_kind_of(Enumerable)
+        expect(subject.check_rubygems(rubygems)).to be_kind_of(Enumerable)
       end
     end
   end
@@ -44,7 +44,7 @@ describe RubyAudit::Database do
         expect(advisories.all? do |advisory|
                  advisory.is_a?(Bundler::Audit::Advisory)
                end).to be_truthy
-        expect(advisories.map(&:id)).to include('OSVDB-120541')
+        expect(advisories.map(&:id)).to include('CVE-2015-1855')
         expect(advisories.map(&:path).reject { |p| p =~ /rubies/ }).to be_empty
       end
     end

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -18,13 +18,13 @@ describe RubyAudit::Scanner do
       expect(subject.all? do |result|
                result.advisory.vulnerable?(result.gem.version)
              end).to be_truthy
-      expect(subject.map { |r| r.advisory.id }).to include('OSVDB-120541')
+      expect(subject.map { |r| r.advisory.id }).to include('CVE-2015-1855')
     end
 
     it 'respects patch level' do
       stub_const('RUBY_VERSION', '1.9.3')
       stub_const('RUBY_PATCHLEVEL', 392)
-      expect(subject.map { |r| r.advisory.id }).to include('OSVDB-113747')
+      expect(subject.map { |r| r.advisory.id }).to include('CVE-2014-8080')
     end
 
     it 'handles preview versions' do
@@ -32,14 +32,14 @@ describe RubyAudit::Scanner do
       stub_const('RUBY_PATCHLEVEL', -1)
       allow_any_instance_of(RubyAudit::Scanner)
         .to receive(:ruby_version).and_return('2.1.0.dev')
-      expect(subject.map { |r| r.advisory.id }).to include('OSVDB-100113')
+      expect(subject.map { |r| r.advisory.id }).to include('CVE-2013-4164')
     end
 
     context 'when the :ignore option is given' do
-      subject { scanner.scan(ignore: ['OSVDB-120541']) }
+      subject { scanner.scan(ignore: ['CVE-2015-1855']) }
 
       it 'should ignore the specified advisories' do
-        expect(subject.map { |r| r.advisory.id }).not_to include('OSVDB-120541')
+        expect(subject.map { |r| r.advisory.id }).not_to include('CVE-2015-1855')
       end
     end
   end


### PR DESCRIPTION
Welp, I think the check for rubygems vulnerabilities has been broken since February 2021.

#### Problem

I was looking around the [rubysec/ruby-advisory-db](https://github.com/rubysec/ruby-advisory-db) repo while working on #34, and I noticed that the `/libraries` directory that holds the rubygems advisories was gone.  Turns out, it was [moved](https://github.com/rubysec/ruby-advisory-db/commit/5a3640b9f14420ee8d8c8251e6c01cc993c4b4c7) to `/gems/rubygems-update` in July 2019, with a symlink pointing from the old location to the new one, and then the symlink was [removed](https://github.com/rubysec/ruby-advisory-db/commit/ba981f34ba00a6d49bd690da05f335cff506835f) in February 2021.  So since then, RubyAudit isn't finding any advisories for any rubygems version.

The good news is, according to the ruby-advisory-db and [rubygems's changelog](https://github.com/rubygems/rubygems/blob/master/CHANGELOG.md), there doesn't seem to have been any new advisories/CVEs since March 2019 (rubygems v2.7.9 and v3.0.3).  So, theoretically, everyone who had kept their rubygems versions up-to-date in 2021 should not have missed out on any advisories.

#### Solution

I've pointed the rubygems checks at the new home for rubygems advisories, and updated the specs.  Updating the specs also required me to update our vendored copy of ruby-advisory-db (that we only use for testing), since the old copy (from 2016) still stores the advisories in `/libraries`.  What do you think?

I'd also like to set up some automatic way to detect this kind of problem if it happens again.  We don't control ruby-advisory-db and they have no duty to inform us of changes that may break our specific implementation... and RubyAudit development is very sporadic, so it's hard for its devs to be vigilant for breaking changes.  I first thought about a runtime check, but it'd have to error in order to get the user's attention, and they wouldn't be able to do anything about it, so maybe not.  Perhaps we can schedule a github CI integration test to run daily/weekly/monthly, which simulates running RubyAudit with the latest ruby-advisory-db on a bunch of ruby and rubygems version that we know have advisories?